### PR TITLE
Port GStreamer Gst.Message.structure to get_structure()

### DIFF
--- a/olpcgames/video.py
+++ b/olpcgames/video.py
@@ -137,9 +137,9 @@ class Player(object):
 
     def on_sync_message(self, bus, message):
         log.info('Sync: %s', message)
-        if message.structure is None:
+        if message.get_structure is None:
             return
-        if message.structure.get_name() == 'prepare-xwindow-id':
+        if message.get_structure.get_name() == 'prepare-xwindow-id':
             self._synchronized = True
             self._videowidget.set_sink(message.src)
 


### PR DESCRIPTION
### Explanation
Fix #4. This PR ports GStreamer Gst.Message.structure to get_structure()

### Reason
GStreamer project deprecated the structure field of Gst.Message, replacing it with a method get_structure().

### Test result
No error related to the port from GStreamer Gst.Message.structure to get_structure.
```
tonadev@TDPC:~/Documents/Work/OpenSource/code_in/sugarlabs/cuidarme-activity$ sugar-activity

(sugar-activity:3536): Gtk-WARNING **: 10:44:18.088: Theme parsing error: gtk-widgets.css:16:32: The style property GtkExpander:expander-size is deprecated and shouldn't be used anymore. It will be removed in a future version

(sugar-activity:3536): Gtk-WARNING **: 10:44:18.088: Theme parsing error: gtk-widgets.css:17:35: The style property GtkExpander:expander-spacing is deprecated and shouldn't be used anymore. It will be removed in a future version
1541349862.561097 INFO olpcgames.canvas: Creating the pygame canvas
1541349862.562257 INFO olpcgames.canvas: Connecting the pygame canvas
1541349863.023290 INFO olpcgames.canvas: Staring the mainloop
1541349863.023696 INFO olpcgames.canvas: Running mainloop: <function main at 0x7f190875f230>
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
 ***** GAME MODE IS NOW ***** 3
 ***** GAME MODE IS NOW ***** 9
libpng warning: iCCP: known incorrect sRGB profile
 ***** GAME MODE IS NOW ***** 2
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
 ***** GAME MODE IS NOW ***** 1
Key KP_Next unrecognized
Key KP_Next unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
Key KP_Begin unrecognized
 ***** GAME MODE IS NOW ***** 10
1541349996.778351 DEBUG olpcgames.canvas: Clearing any pending events
Killed

```
